### PR TITLE
Running on arbitrary audio length

### DIFF
--- a/pytorch/wavenet_infer.h
+++ b/pytorch/wavenet_infer.h
@@ -27,28 +27,35 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 // ------------------------------------------------
 // C-compatible function for wrapper
 // ------------------------------------------------
-void wavenet_infer(int sample_count,
-                   int batch_size,
-                   float* embedding_prev,
-                   float* embedding_curr,
-                   int num_layers,
-                   int max_dilation,
-                   float** in_layer_weights_prev,
-                   float** in_layer_weights_curr,
-                   float** in_layer_biases,
-                   float** res_layer_weights,
-                   float** res_layer_biases,
-                   float** skip_layer_weights,
-                   float** skip_layer_biases,
-                   float* conv_out_weight,
-                   float* conv_end_weight,
-                   int use_embed_tanh,
+void* wavenet_construct(int sample_count,
+                        int batch_size,
+                        float* embedding_prev,
+                        float* embedding_curr,
+                        int num_layers,
+                        int max_dilation,
+                        float** in_layer_weights_prev,
+                        float** in_layer_weights_curr,
+                        float** in_layer_biases,
+                        float** res_layer_weights,
+                        float** res_layer_biases,
+                        float** skip_layer_weights,
+                        float** skip_layer_biases,
+                        float* conv_out_weight,
+                        float* conv_end_weight,
+                        int use_embed_tanh,
+                        int implementation);
+
+void wavenet_infer(void* wavenet,
+                   int* samples,
                    float* cond_input,
-                   int implementation,
-                   int* samples);
+                   int sample_count,
+                   int batch_size);
+
+void wavenet_destruct(void* wavenet);
 
 // --------------------------------------------------------
 // For checking the number of channels match current build

--- a/pytorch/wavenet_infer_wrapper.h
+++ b/pytorch/wavenet_infer_wrapper.h
@@ -24,18 +24,25 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  ******************************************************************************/
-int infer(THCudaIntTensor* samples, 
-          int sample_count,
-          int batch_size,
-          THCudaTensor* embed_prev_tensor,
-          THCudaTensor* embed_curr_tensor,
-          THCudaTensor* conv_out_tensor,
-          THCudaTensor* conv_end_tensor,
+uint64_t construct(int sample_count,
+                   int batch_size,
+                   THCudaTensor* embed_prev_tensor,
+                   THCudaTensor* embed_curr_tensor,
+                   THCudaTensor* conv_out_tensor,
+                   THCudaTensor* conv_end_tensor,
+                   int num_layers,
+                   int use_embed_tanh,
+                   int max_dilation,
+                   int implementation, ...);
+
+int infer(uint64_t wavenet,
+          THCudaIntTensor* samples_tensor,
           THCudaTensor* cond_input_tensor,
-          int num_layers,
-          int use_embed_tanh,
-          int max_dilation,
-          int implementation, ...);
+          int sample_count,
+          int batch_size);
+
+int destruct(uint64_t wavenet);
+
 int num_res_channels(void);
 int num_skip_channels(void);
 int num_out_channels(void);


### PR DESCRIPTION
Currently the Pytorch wrapper builds a single giant array for `cond_input`, with which the GPU quickly runs out of memory, making inference for anything longer than 10 seconds difficult.

This PR modifies the Pytorch wrapper to run the inference in a streaming manner, by splitting the Mel spectrogram into groups of 80 frames (corresponding to 1 second with the default config) and running the inference one by one.

It seamlessly connects the autoregressive output of the previous split to the next, so this 80-frame splits are not audible at all in the resulting audio.

To achieve this, this PR made the following modifications:

- moved `silenceInputs()` call to the constructor of `nvWavenetInfer`. This is the only change in the root directory.
- divided the responsibility of the previously one-off method `infer` to a `construct`-`infer`-`destruct` lifecycle, and made the corresponding edits in `wavenet_infer.{cu,h}` and `wavenet_infer_wrapper.{c,h}` files.
- `nv_wavenet.py` now manages the `nvWavenetInfer` instance through its lifecycle and makes the appropriate calls to `construct`, `infer`, and `destruct` functions. It sets the `m_maxBatch` and `m_maxSamples` as the size of the first `cond_input` it takes; this allows running inference with a smaller conditional input than the first, e.g. the last split of the Mel spectrogram.
- `inference.py` deals with splitting the Mel spectrogram and calling `nv_wavenet` split-by-split. I've also added a verbose option to run the loop with `tqdm`; let me know if the maintainers don't favor this.

I'm not sure if you're accepting PRs, but hope you will! I'm open to suggestions as to code formatting or any other issues.