### PR TITLE
Add pause/resume and CPU-asynchronous generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ In all three implementations, a single kernel runs inference for potentially man
 
 # Usage
 
-nv_wavenet.cuh provides a templated class `nvWavenetInfer`.  The template parameters are:
-* T_weight : should be `float` for fp32 inference, `half2` for fp16 inference
-* T_data : should be `float` for fp32 inference, `half` for fp16 inference
-* R : the number of residual channels  
-* S : the number of skip channels
-* A : the number of audio channels
+`nv_wavenet.cuh` provides a templated class `nvWavenetInfer`.  The template parameters are:
+* `T_weight` : should be `float` for fp32 inference, `half2` for fp16 inference
+* `T_data` : should be `float` for fp32 inference, `half` for fp16 inference
+* `R` : the number of residual channels
+* `S` : the number of skip channels
+* `A` : the number of audio channels
 
 The `nvWavenetInfer` constructor accepts the following arguments:
-* numLayers : the number of residual layers in the WaveNet
-* maxDilation : the maximum dilation amount.  The dilated convolution of each residual layer will have dilation equal to twice the dilation of the prior layer, until this maximum value is reached.  The next layer will then reset its dilation to 1.
-* batchSize : the inference batch size (the number of utterances to generate in parallel)
-* sampleCount : the number of audio samples to generate
-* implementation : the implementation variant to use, as defined by the `nvWavenetInfer::Implementation` enum.  Options are SINGLE_BLOCK, DUAL_BLOCK and PERSISTENT
-* tanhEmbed : specifies whether the result of the input embedding should pass through a tanh
+* `numLayers` : the number of residual layers in the WaveNet
+* `maxDilation` : the maximum dilation amount.  The dilated convolution of each residual layer will have dilation equal to twice the dilation of the prior layer, until this maximum value is reached.  The next layer will then reset its dilation to 1.
+* `batchSize` : the inference batch size (the number of utterances to generate in parallel)
+* `sampleCount` : the number of audio samples to generate
+* `implementation` : the implementation variant to use, as defined by the `nvWavenetInfer::Implementation` enum.  Options are `SINGLE_BLOCK`, `DUAL_BLOCK` and `PERSISTENT`
+* `tanhEmbed` : specifies whether the result of the input embedding should pass through a tanh
 
 Once the `nvWavenetInfer` object is constructed, it is necessary to upload weights for the model.  Weight matrices are provided as `float*` arrays, in column-major order.  In the fp16 case, data conversion and vectorization is provided automatically by the weight upload functions. The provided pointers can be on the host or on the device - in either case, the data will be copied to a buffer belonging to the `NvWavenetInfer` object.
 
@@ -43,24 +43,25 @@ The `nvWavenetInfer::setInputs()` method allows the user to upload conditioning 
 
 # Testing
 
-nv-wavenet includes a simple reference implementation in nv_wavenet_reference.h and nv_wavenet_reference.cpp.  nv_wavenet_test.cu runs the reference implementation against the CUDA configuration for several configurations with random weights.  To run:
-
+nv-wavenet includes a simple reference implementation in `nv_wavenet_reference.h` and `nv_wavenet_reference.cpp`.  `nv_wavenet_test.cu` runs the reference implementation against the CUDA configuration for several configurations with random weights.  To run:
+```
 make nv_wavenet_test
 ./nv_wavenet_test
+```
 
 # Performance
 
-nv_wavenet_perf.cu provides a simple performance test.
+`nv_wavenet_perf.cu` provides a simple performance test.
 
-Before performance testing, it is recommended to fix the GPU clocks using nvidia-smi.  To query available clocks, run nvidia-smi -q -d SUPPORTED_CLOCKS.  The clock can then be set using nvidia-smi -ac
+Before performance testing, it is recommended to fix the GPU clocks using `nvidia-smi`.  To query available clocks, run `nvidia-smi -q -d SUPPORTED_CLOCKS`.  The clock can then be set using `nvidia-smi -ac`
 
 To build and run the performance test, run:
-
+```
 make nv_wavenet_perf
 
 ./nv_wavenet_perf <-l num_layers> <-r residual__channels> <-s skip_channels> <-a audio_channels> <-b batch_size> <-c batch_size_per_block> <-n num_samples> <-d max_dilation> <-m mode> <-p precision>
-
-Finding the best performance at a particular sample rate will require experimenting with different values for batch_size, batch_size_per_block and mode.  batch_size must be a multiple of batch_size_per_block
+```
+Finding the best performance at a particular sample rate will require experimenting with different values for `batch_size`, `batch_size_per_block` and mode.  `batch_size` must be a multiple of `batch_size_per_block`
 
 # Open Source License
 

--- a/nv_wavenet.cuh
+++ b/nv_wavenet.cuh
@@ -39,6 +39,8 @@
 template <typename T_weight, typename T_data >
 struct nv_wavenet_params {
     int num_samples;
+    int num_samples_per_chunk;
+    int init_sample;
     int batch_size;
     int num_layers;
     int* yInPrev;
@@ -275,6 +277,7 @@ class nvWavenetInfer {
         int m_maxDilation;
 
         int m_maxSamples;
+        int m_num_samples_per_chunk;
 
         void setActivation(float* dst, float* src, size_t size) {
             gpuErrChk(cudaMemcpy(dst, src, size*sizeof(float), cudaMemcpyDefault));
@@ -304,7 +307,7 @@ class nvWavenetInfer {
     public:
         nvWavenetInfer (int numLayers, int maxDilation, int batchSize, int numSamples, int impl=0, bool tanhEmbed=true) : m_numLayers(numLayers), m_maxBatch(batchSize), m_maxSamples(numSamples), m_implementation((nvWavenetInfer::Implementation)impl), m_tanhEmbed(tanhEmbed) {
 
-
+            m_num_samples_per_chunk = 0;
             m_maxDilation = maxDilation;
 
             gpuErrChk(cudaMalloc(&m_yOut, numSamples*batchSize*sizeof(int))); // one-hot vector represented as single value indicating which value is set
@@ -430,8 +433,67 @@ class nvWavenetInfer {
             getActivation(hZa, m_out + finalOffset, m_maxBatch*A); 
         }
         void getP(float* hP) { getActivation(hP, m_p, m_maxBatch*A); }
+        void getYOut(int* yOut, int offset, int size, cudaStream_t stream = 0) {
+            size_t cpy_pitch = m_maxSamples * sizeof(int); // spacing between chunk first elements
+            size_t cpy_width = size * sizeof(int); // size of individual chunk
+            size_t cpy_height = m_maxBatch;
+            gpuErrChk(cudaMemcpy2DAsync(yOut + offset, cpy_pitch, m_yOut + offset, cpy_pitch, cpy_width, cpy_height, cudaMemcpyDeviceToHost, stream));
+        }
+        template<class Callback>
+        bool run_chunks(int num_samples_per_chunk, Callback consume, int num_samples, int batch_size, int* yOut=NULL, int batch_size_per_block=1, bool dumpActivations=false, cudaStream_t stream = 0) {
+            bool result = true;
+            cudaStream_t stream_compute, stream_copy;
+            if(!stream)
+              cudaStreamCreate(&stream_compute);
+            else
+              stream_compute = stream;
+            cudaStreamCreate(&stream_copy);
+            m_num_samples_per_chunk = num_samples_per_chunk;
+            int num_chunks = (num_samples + m_num_samples_per_chunk - 1) / m_num_samples_per_chunk;
 
-        bool run(int num_samples, int batch_size, int* yOut=NULL, int batch_size_per_block=1, bool dumpActivations=false, cudaStream_t stream = 0) {
+            std::vector<cudaEvent_t> event_compute(num_chunks);
+            std::vector<cudaEvent_t> event_copy(num_chunks);
+            for (int j = 0; j < num_chunks; j++) {
+              cudaEventCreateWithFlags(&(event_compute[j]), cudaEventDisableTiming);
+              cudaEventCreateWithFlags(&(event_copy[j]), cudaEventDisableTiming);
+            }
+
+            for (int j = 0; j < num_chunks; j++) {
+
+              int initSample = j*m_num_samples_per_chunk;
+              if (j == num_chunks - 1) {
+                m_num_samples_per_chunk = num_samples - initSample;
+              }
+
+              result = result && run(initSample, num_samples, batch_size, NULL, batch_size_per_block, true, stream_compute);
+              cudaEventRecord(event_compute[j], stream_compute);
+              cudaStreamWaitEvent(stream_copy, event_compute[j], 0);
+              if(yOut != NULL)
+                getYOut(yOut, initSample, m_num_samples_per_chunk, stream_copy);
+              cudaEventRecord(event_copy[j], stream_copy);
+            }
+            m_num_samples_per_chunk = num_samples_per_chunk;
+            for (int j = 0; j < num_chunks; j++) {
+
+              int initSample = j*m_num_samples_per_chunk;
+              if (j == num_chunks - 1) {
+                m_num_samples_per_chunk = num_samples - initSample;
+              }
+              cudaEventSynchronize(event_copy[j]);
+              consume(yOut, initSample, m_num_samples_per_chunk);
+            }
+            m_num_samples_per_chunk = 0;
+            for (int j = 0; j < num_chunks; j++) {
+              cudaEventDestroy(event_compute[j]);
+              cudaEventDestroy(event_copy[j]);
+            }
+            if(stream != stream_compute)
+              cudaStreamDestroy(stream_compute);
+            cudaStreamDestroy(stream_copy);
+            return result;
+        }
+
+        bool run(int init_sample, int num_samples, int batch_size, int* yOut=NULL, int batch_size_per_block=1, bool dumpActivations=false, cudaStream_t stream = 0) {
 
             Implementation impl = m_implementation;
             if (impl == AUTO) {
@@ -448,6 +510,8 @@ class nvWavenetInfer {
 
             nv_wavenet_params<T_weight, T_data> params;
             params.num_samples = num_samples;
+            params.init_sample = init_sample;
+            params.num_samples_per_chunk = m_num_samples_per_chunk ? m_num_samples_per_chunk : num_samples;
             params.batch_size = batch_size;
             params.num_layers = m_numLayers;
             params.yInPrev = m_yInPrev;

--- a/nv_wavenet_perf.cu
+++ b/nv_wavenet_perf.cu
@@ -26,12 +26,13 @@
  ******************************************************************************/
 
 #include "nv_wavenet.cuh"
+#include <cuda_profiler_api.h>
 #include <stdio.h>
 #include <vector>
 #include <unistd.h>
 
 template <typename T_weight, typename T_data, int R, int S, int A>
-float getSampleRateT(int num_layers, int max_dilation, int batch_size, int batch_size_per_block, int num_samples, int mode) {
+float getSampleRateT(int num_layers, int max_dilation, int batch_size, int batch_size_per_block, int num_samples, int num_samples_per_chunk, int mode) {
 
     // Set up initial activations
 
@@ -67,7 +68,13 @@ float getSampleRateT(int num_layers, int max_dilation, int batch_size, int batch
     gpuErrChk(cudaEventCreate(&start));
     gpuErrChk(cudaEventCreate(&stop));
     gpuErrChk(cudaEventRecord(start));
-    bool success = infer.run(num_samples,batch_size, NULL, batch_size_per_block);
+    int* mcYout;
+    // because the chunked version copies repeatedly, we should measure it as well.
+    gpuErrChk(cudaMallocHost(&mcYout, num_samples*batch_size*sizeof(int)));
+    cudaProfilerStart();
+    bool success = infer.run_chunks(num_samples_per_chunk, [](int*, int, int){}, num_samples, batch_size, mcYout, batch_size_per_block);
+    gpuErrChk(cudaFreeHost(mcYout));
+
     gpuErrChk(cudaEventRecord(stop));
 
     gpuErrChk(cudaEventSynchronize(stop));
@@ -80,36 +87,36 @@ float getSampleRateT(int num_layers, int max_dilation, int batch_size, int batch
 
 }
 
-float getSampleRate(int precision, int r, int s, int a, int num_layers, int max_dilation, int batch_size, int batch_size_per_block, int num_samples, int mode) {
+float getSampleRate(int precision, int r, int s, int a, int num_layers, int max_dilation, int batch_size, int batch_size_per_block, int num_samples, int num_samples_per_chunk, int mode) {
     assert(a==256);
     float sample_rate;
     if (r == 32) {
         assert(s==128);
         assert(a==256);
         if (precision == 16) {
-                sample_rate = getSampleRateT<half2,half,32,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+	    sample_rate = getSampleRateT<half2,half,32,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
         }
         else {
             assert(precision==32);
-                sample_rate = getSampleRateT<float,float,32,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+	    sample_rate = getSampleRateT<float,float,32,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
         }
     }
     else {
         assert(r==64);
         if (precision == 16) {
             if (s==128) 
-                sample_rate = getSampleRateT<half2,half,64,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+                sample_rate = getSampleRateT<half2,half,64,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
             else if (s==256)
-                sample_rate = getSampleRateT<half2,half,64,256,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+                sample_rate = getSampleRateT<half2,half,64,256,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
             else
                 assert(false);
         }
         else {
             assert(precision==32);
             if (s==128) 
-                sample_rate = getSampleRateT<float,float,64,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+                sample_rate = getSampleRateT<float,float,64,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
             else if (s==256)
-                sample_rate = getSampleRateT<float,float,64,256,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+                sample_rate = getSampleRateT<float,float,64,256,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
             else
                 assert(false);
         }
@@ -146,9 +153,10 @@ int main(int argc, char* argv[]) {
     int max_dilation = 512;
     int mode = 0;
     int precision = 16;
+    int num_samples_per_chunk = 2048;
 
     int c;
-    while ((c = getopt (argc, argv, "l:r:s:a:b:n:c:d:m:p:")) != -1) {
+    while ((c = getopt (argc, argv, "l:r:s:a:b:n:c:d:m:p:t:")) != -1) {
         switch (c) {
             case 'l':
                 num_layers = atoi(optarg);
@@ -179,6 +187,9 @@ int main(int argc, char* argv[]) {
                 break;
             case 'p':
                 precision = atoi(optarg);
+                break;
+            case 't':
+                num_samples_per_chunk = atoi(optarg);
                 break;
             default:
                 assert(false);
@@ -216,6 +227,6 @@ int main(int argc, char* argv[]) {
 
     srand(1);
 
-    float sample_rate = getSampleRate(precision, r, s, a, num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+    float sample_rate = getSampleRate(precision, r, s, a, num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
     printf("Sample rate: %f kHz\n", sample_rate);
 }

--- a/nv_wavenet_test.cu
+++ b/nv_wavenet_test.cu
@@ -250,7 +250,9 @@ void runTest(int num_layers, int max_dilation, int batch_size, int num_iteration
         int* mcYout = (int*)malloc(samples_per_iteration*batch_size*sizeof(int));
 
         ref.run(samples_per_iteration, batch_size, refYout);
-        assert(infer->run(samples_per_iteration, batch_size, mcYout, batch_size_per_block, true));
+
+        assert(infer->run_chunks(7, [](int*, int, int){}, samples_per_iteration, batch_size, mcYout, batch_size_per_block));
+
         gpuErrChk(cudaDeviceSynchronize());
 
         // Check results
@@ -301,6 +303,8 @@ void runTest(int num_layers, int max_dilation, int batch_size, int num_iteration
         for (int i=0; i<samples_per_iteration*batch_size; i++) {
             assert(refYout[i] == mcYout[i]);
         }
+        free(mcYout);
+        free(refYout);
 
         printf("SUCCESS!\n");
     }
@@ -362,5 +366,4 @@ int main(int argc, char* argv[]) {
     runTest<float,float,64,256, 256>(num_layers, MAX_DILATION, batch_size, 2, SAMPLES_PER_ITERATION, 2);
     printf("   Testing Persistent\n");
     runTest<float,float,64,256, 256>(num_layers, MAX_DILATION, batch_size, 2, SAMPLES_PER_ITERATION, 3);
-
 }


### PR DESCRIPTION
The change allows the kernels to reuse last activations when invoked on subsequent chunks.
The host code has a new interface, nvWavenetInfer::run_chunks(...), which accepts
a lambda callback for any CPU postprocessing, one chunk per call (encoding, sending
over the network, etc.). Performance of non-chunked codepath is unaffected, and
the per-chunk overhead is negligible for realistic chunk sizes.
However, the whole activation tensors still need to be allocated on the GPU.
The code has not been tested for first-chunk latency when scheduling thousands of chunks.