### PR TITLE
Add pause/resume and CPU-asynchronous generation; integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,17 @@ nv_wavenet_test : nv_wavenet_test.cu matrix.cpp matrix.h nv_wavenet_reference.cp
 math_test : math_test.cu matrix_math.cuh matrix.cpp softmax.cuh
 	$(NVCC) $(NVCC_FLAGS) math_test.cu matrix.cpp -lineinfo -o math_test
 
+pytorch/_nv_wavenet_ext.so:
+	$(MAKE) -C pytorch
+	cd pytorch; python3 ./build.py
+
+submodules:
+	git submodule update --init
+
+integration_test: submodules nv_wavenet_test pytorch/_nv_wavenet_ext.so
+	./nv_wavenet_test
+	cd pytorch; python3 ./integration_test.py
+
 clean:
 	rm  nv_wavenet_perf nv_wavenet_test math_test
 

--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ In all three implementations, a single kernel runs inference for potentially man
 
 # Usage
 
-nv_wavenet.cuh provides a templated class `nvWavenetInfer`.  The template parameters are:
-* T_weight : should be `float` for fp32 inference, `half2` for fp16 inference
-* T_data : should be `float` for fp32 inference, `half` for fp16 inference
-* R : the number of residual channels  
-* S : the number of skip channels
-* A : the number of audio channels
+`nv_wavenet.cuh` provides a templated class `nvWavenetInfer`.  The template parameters are:
+* `T_weight` : should be `float` for fp32 inference, `half2` for fp16 inference
+* `T_data` : should be `float` for fp32 inference, `half` for fp16 inference
+* `R` : the number of residual channels  
+* `S` : the number of skip channels
+* `A` : the number of audio channels
 
 The `nvWavenetInfer` constructor accepts the following arguments:
-* numLayers : the number of residual layers in the WaveNet
-* maxDilation : the maximum dilation amount.  The dilated convolution of each residual layer will have dilation equal to twice the dilation of the prior layer, until this maximum value is reached.  The next layer will then reset its dilation to 1.
-* batchSize : the inference batch size (the number of utterances to generate in parallel)
-* sampleCount : the number of audio samples to generate
-* implementation : the implementation variant to use, as defined by the `nvWavenetInfer::Implementation` enum.  Options are SINGLE_BLOCK, DUAL_BLOCK and PERSISTENT
-* tanhEmbed : specifies whether the result of the input embedding should pass through a tanh
+* `numLayers` : the number of residual layers in the WaveNet
+* `maxDilation` : the maximum dilation amount.  The dilated convolution of each residual layer will have dilation equal to twice the dilation of the prior layer, until this maximum value is reached.  The next layer will then reset its dilation to 1.
+* `batchSize` : the inference batch size (the number of utterances to generate in parallel)
+* `sampleCount` : the number of audio samples to generate
+* `implementation` : the implementation variant to use, as defined by the `nvWavenetInfer::Implementation` enum.  Options are `SINGLE_BLOCK`, `DUAL_BLOCK` and `PERSISTENT`
+* `tanhEmbed` : specifies whether the result of the input embedding should pass through a tanh
 
 Once the `nvWavenetInfer` object is constructed, it is necessary to upload weights for the model.  Weight matrices are provided as `float*` arrays, in column-major order.  In the fp16 case, data conversion and vectorization is provided automatically by the weight upload functions. The provided pointers can be on the host or on the device - in either case, the data will be copied to a buffer belonging to the `NvWavenetInfer` object.
 
@@ -43,24 +43,25 @@ The `nvWavenetInfer::setInputs()` method allows the user to upload conditioning 
 
 # Testing
 
-nv-wavenet includes a simple reference implementation in nv_wavenet_reference.h and nv_wavenet_reference.cpp.  nv_wavenet_test.cu runs the reference implementation against the CUDA configuration for several configurations with random weights.  To run:
-
+nv-wavenet includes a simple reference implementation in `nv_wavenet_reference.h` and `nv_wavenet_reference.cpp`.  `nv_wavenet_test.cu` runs the reference implementation against the CUDA configuration for several configurations with random weights.  To run:
+```
 make nv_wavenet_test
 ./nv_wavenet_test
+```
 
 # Performance
 
-nv_wavenet_perf.cu provides a simple performance test.
+`nv_wavenet_perf.cu` provides a simple performance test.
 
-Before performance testing, it is recommended to fix the GPU clocks using nvidia-smi.  To query available clocks, run nvidia-smi -q -d SUPPORTED_CLOCKS.  The clock can then be set using nvidia-smi -ac
+Before performance testing, it is recommended to fix the GPU clocks using `nvidia-smi`.  To query available clocks, run `nvidia-smi -q -d SUPPORTED_CLOCKS`.  The clock can then be set using `nvidia-smi -ac`
 
 To build and run the performance test, run:
-
+```
 make nv_wavenet_perf
 
 ./nv_wavenet_perf <-l num_layers> <-r residual__channels> <-s skip_channels> <-a audio_channels> <-b batch_size> <-c batch_size_per_block> <-n num_samples> <-d max_dilation> <-m mode> <-p precision>
-
-Finding the best performance at a particular sample rate will require experimenting with different values for batch_size, batch_size_per_block and mode.  batch_size must be a multiple of batch_size_per_block
+```
+Finding the best performance at a particular sample rate will require experimenting with different values for `batch_size`, `batch_size_per_block` and mode.  `batch_size` must be a multiple of `batch_size_per_block`
 
 # Open Source License
 

--- a/nv_wavenet_perf.cu
+++ b/nv_wavenet_perf.cu
@@ -26,12 +26,13 @@
  ******************************************************************************/
 
 #include "nv_wavenet.cuh"
+#include <cuda_profiler_api.h>
 #include <stdio.h>
 #include <vector>
 #include <unistd.h>
 
 template <typename T_weight, typename T_data, int R, int S, int A>
-float getSampleRateT(int num_layers, int max_dilation, int batch_size, int batch_size_per_block, int num_samples, int mode) {
+float getSampleRateT(int num_layers, int max_dilation, int batch_size, int batch_size_per_block, int num_samples, int num_samples_per_chunk, int mode) {
 
     // Set up initial activations
 
@@ -67,7 +68,13 @@ float getSampleRateT(int num_layers, int max_dilation, int batch_size, int batch
     gpuErrChk(cudaEventCreate(&start));
     gpuErrChk(cudaEventCreate(&stop));
     gpuErrChk(cudaEventRecord(start));
-    bool success = infer.run(num_samples,batch_size, NULL, batch_size_per_block);
+    int* mcYout;
+    // because the chunked version copies repeatedly, we should measure it as well.
+    gpuErrChk(cudaMallocHost(&mcYout, num_samples*batch_size*sizeof(int)));
+    cudaProfilerStart();
+    bool success = infer.run_chunks(num_samples_per_chunk, [](int*, int, int){}, num_samples, batch_size, mcYout, batch_size_per_block);
+    gpuErrChk(cudaFreeHost(mcYout));
+
     gpuErrChk(cudaEventRecord(stop));
 
     gpuErrChk(cudaEventSynchronize(stop));
@@ -80,36 +87,36 @@ float getSampleRateT(int num_layers, int max_dilation, int batch_size, int batch
 
 }
 
-float getSampleRate(int precision, int r, int s, int a, int num_layers, int max_dilation, int batch_size, int batch_size_per_block, int num_samples, int mode) {
+float getSampleRate(int precision, int r, int s, int a, int num_layers, int max_dilation, int batch_size, int batch_size_per_block, int num_samples, int num_samples_per_chunk, int mode) {
     assert(a==256);
     float sample_rate;
     if (r == 32) {
         assert(s==128);
         assert(a==256);
         if (precision == 16) {
-                sample_rate = getSampleRateT<half2,half,32,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+	    sample_rate = getSampleRateT<half2,half,32,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
         }
         else {
             assert(precision==32);
-                sample_rate = getSampleRateT<float,float,32,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+	    sample_rate = getSampleRateT<float,float,32,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
         }
     }
     else {
         assert(r==64);
         if (precision == 16) {
             if (s==128) 
-                sample_rate = getSampleRateT<half2,half,64,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+                sample_rate = getSampleRateT<half2,half,64,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
             else if (s==256)
-                sample_rate = getSampleRateT<half2,half,64,256,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+                sample_rate = getSampleRateT<half2,half,64,256,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
             else
                 assert(false);
         }
         else {
             assert(precision==32);
             if (s==128) 
-                sample_rate = getSampleRateT<float,float,64,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+                sample_rate = getSampleRateT<float,float,64,128,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
             else if (s==256)
-                sample_rate = getSampleRateT<float,float,64,256,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+                sample_rate = getSampleRateT<float,float,64,256,256>(num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
             else
                 assert(false);
         }
@@ -146,9 +153,10 @@ int main(int argc, char* argv[]) {
     int max_dilation = 512;
     int mode = 0;
     int precision = 16;
+    int num_samples_per_chunk = 2048;
 
     int c;
-    while ((c = getopt (argc, argv, "l:r:s:a:b:n:c:d:m:p:")) != -1) {
+    while ((c = getopt (argc, argv, "l:r:s:a:b:n:c:d:m:p:t:")) != -1) {
         switch (c) {
             case 'l':
                 num_layers = atoi(optarg);
@@ -179,6 +187,9 @@ int main(int argc, char* argv[]) {
                 break;
             case 'p':
                 precision = atoi(optarg);
+                break;
+            case 't':
+                num_samples_per_chunk = atoi(optarg);
                 break;
             default:
                 assert(false);
@@ -216,6 +227,6 @@ int main(int argc, char* argv[]) {
 
     srand(1);
 
-    float sample_rate = getSampleRate(precision, r, s, a, num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, mode);
+    float sample_rate = getSampleRate(precision, r, s, a, num_layers, max_dilation, batch_size, batch_size_per_block, num_samples, num_samples_per_chunk, mode);
     printf("Sample rate: %f kHz\n", sample_rate);
 }

--- a/nv_wavenet_persistent.cuh
+++ b/nv_wavenet_persistent.cuh
@@ -92,7 +92,7 @@ __device__ __inline__ void sampleLockAcquire(int batch_offset, int sample, volat
 
 /* GEMM Tile -- M threads, with K weights held in registers */
 template <typename T_weight, typename T_data, int M, int K, int N_UNROLL>
-__device__ void nv_wavenet_persistent_GEMM_MxK(int thread_id, int num_samples, volatile int* ySample, int layer, int num_layers, int batch_size, T_weight* W, T_data* B, volatile T_data* act_in, T_data* act_out, volatile T_data* accum_in=NULL, int lda=M, int ldb=K, int ldc=M, bool doRelu=false) {
+__device__ void nv_wavenet_persistent_GEMM_MxK(int thread_id, int num_samples, int init_sample, int num_samples_per_chunk, volatile int* ySample, int layer, int num_layers, int batch_size, T_weight* W, T_data* B, volatile T_data* act_in, T_data* act_out, volatile T_data* accum_in=NULL, int lda=M, int ldb=K, int ldc=M, bool doRelu=false) {
     int row = thread_id;
     const int WV = sizeof(T_weight)/sizeof(T_data);
     T_weight weights[K/WV];
@@ -104,7 +104,7 @@ __device__ void nv_wavenet_persistent_GEMM_MxK(int thread_id, int num_samples, v
     T_data act_in_reg[N_UNROLL];
 
     if (thread_id < M) {
-        for (int sample=0; sample < num_samples; sample++) {
+      for (int sample=init_sample; sample < init_sample + num_samples_per_chunk; sample++) {
             for (int batch_offset = 0; batch_offset < batch_size; batch_offset += N_UNROLL) {
                 // sampleLockacquire has a __syncthreads in it, so we don't need to worry about act_in_sh race
                 sampleLockAcquire<N_UNROLL>(batch_offset, sample, ySample);
@@ -165,7 +165,7 @@ __device__ void nv_wavenet_persistent_GEMM_MxK(int thread_id, int num_samples, v
 
 /* Tiled GEMM, where each tile has TILE_M threads and TILE_K weights */
 template <typename T_weight, typename T_data, int TILE_M, int TILE_K, int BATCH_UNROLL>
-__device__ void nv_wavenet_persistent_GEMM(int thread_id, int num_samples, volatile int* ySample, int tile_id, int batch_size, T_weight* W, T_data* B, volatile T_data* act_in, T_data* act_out, T_data* accum_in, int gemm_m, int gemm_k, bool doRelu=false) {
+__device__ void nv_wavenet_persistent_GEMM(int thread_id, int num_samples, int init_sample, int num_samples_per_chunk, volatile int* ySample, int tile_id, int batch_size, T_weight* W, T_data* B, volatile T_data* act_in, T_data* act_out, T_data* accum_in, int gemm_m, int gemm_k, bool doRelu=false) {
 
    int tiles_m = gemm_m / TILE_M;
    int tiles_k = gemm_k / TILE_K;
@@ -178,11 +178,11 @@ __device__ void nv_wavenet_persistent_GEMM(int thread_id, int num_samples, volat
 
    T_data* bias = (tile_id_k == 0) ? B + tile_offset_m : NULL;
 
-   nv_wavenet_persistent_GEMM_MxK<T_weight, T_data, TILE_M, TILE_K, BATCH_UNROLL>(thread_id, num_samples, ySample, tile_id_k, tiles_k, batch_size, W + tile_offset_m, bias, act_in + tile_offset_k, act_out + tile_offset_m, accum_in + tile_offset_m, gemm_m, gemm_k, gemm_m, doRelu && (tile_id_k == tiles_k-1)); 
+   nv_wavenet_persistent_GEMM_MxK<T_weight, T_data, TILE_M, TILE_K, BATCH_UNROLL>(thread_id, num_samples, init_sample, num_samples_per_chunk, ySample, tile_id_k, tiles_k, batch_size, W + tile_offset_m, bias, act_in + tile_offset_k, act_out + tile_offset_m, accum_in + tile_offset_m, gemm_m, gemm_k, gemm_m, doRelu && (tile_id_k == tiles_k-1)); 
 }
 
 template <typename T_weight, typename T_data, int R, int BATCH_UNROLL>
-__device__ void nv_wavenet_persistent_prev(int row, int num_samples, volatile int* ySample, int layer, int num_layers, int batch_size, int maxDilation, T_weight* Wprev, T_data* a_prev, volatile T_data* xt) {
+__device__ void nv_wavenet_persistent_prev(int row, int num_samples, int init_sample, int num_samples_per_chunk, volatile int* ySample, int layer, int num_layers, int batch_size, int maxDilation, T_weight* Wprev, T_data* a_prev, volatile T_data* xt) {
     const int WV = sizeof(T_weight)/sizeof(T_data);
     T_weight weights[R/WV];
     loadWeights<2*R,R>(weights,Wprev,layer,row);
@@ -196,7 +196,7 @@ __device__ void nv_wavenet_persistent_prev(int row, int num_samples, volatile in
     }
 
     if (row < 2*R) {
-        for (int sample=0; sample<num_samples; sample++) {
+        for (int sample=init_sample; sample<init_sample+num_samples_per_chunk; sample++) {
             int sample_offset = (sample - dilation) % (maxDilation+1);
             volatile T_data* xtmd = xt + sample_offset*(num_layers+1)*R*batch_size;
             for (int batch_offset = 0; batch_offset < batch_size; batch_offset += BATCH_UNROLL) {
@@ -219,7 +219,7 @@ __device__ void nv_wavenet_persistent_prev(int row, int num_samples, volatile in
 }
 
 template <typename T_weight, typename T_data, int R, int BATCH_UNROLL>
-__device__ void nv_wavenet_persistent_cur(int row, int num_samples, volatile int* ySample, int layer, int num_layers, int batch_size, int maxDilation, T_weight* Wcur, T_data* B, T_data* L, T_data a_cur_sh[BATCH_UNROLL][2*R], volatile T_data* a_prev, volatile T_data* xt, int* yInPrev, int* yInCur, T_data* embedPrev, T_data* embedCur, bool tanhEmbed) {
+__device__ void nv_wavenet_persistent_cur(int row, int num_samples, int init_sample, int num_samples_per_chunk, volatile int* ySample, int layer, int num_layers, int batch_size, int maxDilation, T_weight* Wcur, T_data* B, T_data* L, T_data a_cur_sh[BATCH_UNROLL][2*R], volatile T_data* a_prev, volatile T_data* xt, int* yInPrev, int* yInCur, T_data* embedPrev, T_data* embedCur, bool tanhEmbed) {
     const int WV = sizeof(T_weight)/sizeof(T_data);
     T_weight weights[R/WV];
     loadWeights<2*R,R>(weights,Wcur,layer,row);
@@ -227,7 +227,7 @@ __device__ void nv_wavenet_persistent_cur(int row, int num_samples, volatile int
     T_data bias = B[layer*2*R+row];
     T_data a_prev_reg[BATCH_UNROLL];
     T_data xt_in[BATCH_UNROLL];
-    for (int sample=0; sample<num_samples; sample++) {
+    for (int sample=init_sample; sample<init_sample+num_samples_per_chunk; sample++) {
         __syncthreads(); // Wait for initial sample lock
         volatile T_data* Xt = xt + (sample%(maxDilation+1))*(num_layers+1)*R*batch_size;
         for (int batch_offset = 0; batch_offset < batch_size; batch_offset += BATCH_UNROLL) {
@@ -299,14 +299,14 @@ __device__ void nv_wavenet_persistent_cur(int row, int num_samples, volatile int
 }
 
 template <typename T_weight, typename T_data, int R, int BATCH_UNROLL>
-__device__ void nv_wavenet_persistent_res(int row, int num_samples, volatile int* ySample, int layer, int num_layers, int batch_size, int maxDilation, T_weight* Wres, T_data* Bres, T_data a_cur_sh[BATCH_UNROLL][2*R], T_data* xt, T_data* h, T_data* xtOut, bool dumpActivations) {
+__device__ void nv_wavenet_persistent_res(int row, int num_samples, int init_sample, int num_samples_per_chunk, volatile int* ySample, int layer, int num_layers, int batch_size, int maxDilation, T_weight* Wres, T_data* Bres, T_data a_cur_sh[BATCH_UNROLL][2*R], T_data* xt, T_data* h, T_data* xtOut, bool dumpActivations) {
     const int WV = sizeof(T_weight)/sizeof(T_data);
     T_weight weights[R/WV];
     T_data bias = Bres[layer*R+row];
     T_data accum[BATCH_UNROLL];
     __shared__ T_data h_sh[BATCH_UNROLL][R];
     loadWeights<R,R>(weights,Wres,layer,row);
-    for (int sample=0; sample<num_samples; sample++) {
+    for (int sample=init_sample; sample<init_sample+num_samples_per_chunk; sample++) {
         __syncthreads(); // Wait for initial sample lock
         for (int batch_offset = 0; batch_offset < batch_size; batch_offset += BATCH_UNROLL) {
             namedBarrierSync(3,3*R); // a_cur_sh produced, h_sh consumed
@@ -331,10 +331,10 @@ __device__ void nv_wavenet_persistent_res(int row, int num_samples, volatile int
 }
 
 template <typename T_weight, typename T_data, int R, int BATCH_UNROLL>
-__device__ void nv_wavenet_persistent_cur_res(int thread_id, int num_samples, volatile int* ySample, int layer, int num_layers, int batch_size, int maxDilation, T_weight* Wcur, T_data* B, T_data* L, T_weight* Wres, T_data* Bres, T_data* a_prev, T_data* xt, T_data* h, T_data* xtOut, bool dumpActivations, int* yInPrev, int* yInCur, T_data* embedPrev, T_data* embedCur, bool tanhEmbed) {
+__device__ void nv_wavenet_persistent_cur_res(int thread_id, int num_samples, int init_sample, int num_samples_per_chunk, volatile int* ySample, int layer, int num_layers, int batch_size, int maxDilation, T_weight* Wcur, T_data* B, T_data* L, T_weight* Wres, T_data* Bres, T_data* a_prev, T_data* xt, T_data* h, T_data* xtOut, bool dumpActivations, int* yInPrev, int* yInCur, T_data* embedPrev, T_data* embedCur, bool tanhEmbed) {
     __shared__ T_data a_cur_sh[BATCH_UNROLL][2*R];
     if (thread_id < R) {
-        for (int sample=0; sample<num_samples; sample++) {
+        for (int sample=init_sample; sample<init_sample+num_samples_per_chunk; sample++) {
             sampleLockAcquire<BATCH_UNROLL>(0,sample,ySample);
             for (int batch_offset = 0; batch_offset < batch_size; batch_offset += BATCH_UNROLL) {
                 if (batch_offset+BATCH_UNROLL<batch_size) sampleLockAcquire<BATCH_UNROLL>(batch_offset+BATCH_UNROLL,sample,ySample);
@@ -344,17 +344,17 @@ __device__ void nv_wavenet_persistent_cur_res(int thread_id, int num_samples, vo
     }
     else if (thread_id < 3*R) {
         int row = thread_id - R;
-        nv_wavenet_persistent_cur<T_weight, T_data, R, BATCH_UNROLL>(row, num_samples, ySample, layer, num_layers, batch_size, maxDilation, Wcur, B, L, a_cur_sh, a_prev, xt, yInPrev, yInCur, embedPrev, embedCur, tanhEmbed); 
+        nv_wavenet_persistent_cur<T_weight, T_data, R, BATCH_UNROLL>(row, num_samples, init_sample, num_samples_per_chunk, ySample, layer, num_layers, batch_size, maxDilation, Wcur, B, L, a_cur_sh, a_prev, xt, yInPrev, yInCur, embedPrev, embedCur, tanhEmbed); 
     }
     else if (thread_id < 4*R) {
         int row = thread_id - 3*R;
-        nv_wavenet_persistent_res<T_weight, T_data, R, BATCH_UNROLL>(row, num_samples, ySample, layer, num_layers, batch_size, maxDilation, Wres, Bres, a_cur_sh, xt, h, xtOut, dumpActivations);
+        nv_wavenet_persistent_res<T_weight, T_data, R, BATCH_UNROLL>(row, num_samples, init_sample, num_samples_per_chunk, ySample, layer, num_layers, batch_size, maxDilation, Wres, Bres, a_cur_sh, xt, h, xtOut, dumpActivations);
     }
 }
 
 template <typename T_weight, typename T_data, int R, int S, int A, int BATCH_UNROLL>
-__device__ void nv_wavenet_persistent_softmax(int block_id, int batch_size, int num_layers, int num_samples, int maxDilation, volatile T_data* outAccumulate, float* outputSelectors, T_data* p, int* yOut, int* yInPrev, int* yInCur, volatile int* ySample, T_data* xt, T_data* a_prev, T_data* h, T_data* skip_out, T_data* skipOutAccumulate, bool dumpActivations) {
-    for (int sample = 0; sample < num_samples; sample++) {
+__device__ void nv_wavenet_persistent_softmax(int block_id, int batch_size, int num_layers, int num_samples, int init_sample, int num_samples_per_chunk, int maxDilation, volatile T_data* outAccumulate, float* outputSelectors, T_data* p, int* yOut, int* yInPrev, int* yInCur, volatile int* ySample, T_data* xt, T_data* a_prev, T_data* h, T_data* skip_out, T_data* skipOutAccumulate, bool dumpActivations) {
+    for (int sample = init_sample; sample < init_sample+num_samples_per_chunk; sample++) {
         __shared__ T_data out_sh[BATCH_UNROLL][A];
         __shared__ T_data p_sh[BATCH_UNROLL][A];
         __shared__ int yOut_sh[BATCH_UNROLL];
@@ -470,12 +470,12 @@ __global__ void nv_wavenet_persistent(nv_wavenet_params<T_weight, T_data> params
     if (blockIdx.x < prev_blocks) {
         // Prev
         int layer = blockIdx.x;
-        nv_wavenet_persistent_prev<T_weight, T_data, R, BATCH_UNROLL>(thread_id, params.num_samples, params.ySample, layer, params.num_layers, params.batch_size, params.maxDilation, params.Wprev, params.a_prev, params.xt);
+        nv_wavenet_persistent_prev<T_weight, T_data, R, BATCH_UNROLL>(thread_id, params.num_samples, params.init_sample, params.num_samples_per_chunk, params.ySample, layer, params.num_layers, params.batch_size, params.maxDilation, params.Wprev, params.a_prev, params.xt);
     }
     else if (blockIdx.x < prev_blocks + cur_blocks) {
         // Cur
         int layer = blockIdx.x - prev_blocks;
-        nv_wavenet_persistent_cur_res<T_weight, T_data, R, BATCH_UNROLL>(thread_id, params.num_samples, params.ySample, layer, params.num_layers, params.batch_size, params.maxDilation, params.Wcur, params.B, params.L, params.Wres, params.Bres, params.a_prev, params.xt, params.h, params.xtOut, params.dumpActivations, params.yInPrev, params.yInCur, params.embedPrev, params.embedCur, params.tanhEmbed);
+        nv_wavenet_persistent_cur_res<T_weight, T_data, R, BATCH_UNROLL>(thread_id, params.num_samples, params.init_sample, params.num_samples_per_chunk, params.ySample, layer, params.num_layers, params.batch_size, params.maxDilation, params.Wcur, params.B, params.L, params.Wres, params.Bres, params.a_prev, params.xt, params.h, params.xtOut, params.dumpActivations, params.yInPrev, params.yInCur, params.embedPrev, params.embedCur, params.tanhEmbed);
     }
     else if (blockIdx.x < prev_blocks + cur_blocks + skip_blocks) {
         // Skip
@@ -483,20 +483,20 @@ __global__ void nv_wavenet_persistent(nv_wavenet_params<T_weight, T_data> params
         int layer = block_id*s_tiles;
         int tile = block_id%s_tiles;
         int tile_offset = tile*S_TILE;
-        nv_wavenet_persistent_GEMM_MxK<T_weight, T_data, S_TILE, R, BATCH_UNROLL>(thread_id, params.num_samples, params.ySample,layer, params.num_layers, params.batch_size, params.Wskip + tile_offset, params.Bskip + tile_offset, params.h + layer*params.batch_size*R, params.skip_out + tile_offset, params.skip_out + tile_offset, S, R, S, layer==params.num_layers-1);
+        nv_wavenet_persistent_GEMM_MxK<T_weight, T_data, S_TILE, R, BATCH_UNROLL>(thread_id, params.num_samples, params.init_sample, params.num_samples_per_chunk, params.ySample,layer, params.num_layers, params.batch_size, params.Wskip + tile_offset, params.Bskip + tile_offset, params.h + layer*params.batch_size*R, params.skip_out + tile_offset, params.skip_out + tile_offset, S, R, S, layer==params.num_layers-1);
     }
     // AxS
     else if (blockIdx.x < prev_blocks + cur_blocks + skip_blocks + Zs_blocks) {
         int tile_id = blockIdx.x - prev_blocks - cur_blocks - skip_blocks;
-        nv_wavenet_persistent_GEMM<T_weight, T_data, 4*R, R, BATCH_UNROLL>(thread_id, params.num_samples, params.ySample, tile_id, params.batch_size, params.WskipOut, params.BskipOut, params.skip_out + (params.num_layers-1)*params.batch_size*S, params.skipOutFinal, params.skipOutAccumulate, A, S, true);
+        nv_wavenet_persistent_GEMM<T_weight, T_data, 4*R, R, BATCH_UNROLL>(thread_id, params.num_samples, params.init_sample, params.num_samples_per_chunk, params.ySample, tile_id, params.batch_size, params.WskipOut, params.BskipOut, params.skip_out + (params.num_layers-1)*params.batch_size*S, params.skipOutFinal, params.skipOutAccumulate, A, S, true);
     }
     else if (blockIdx.x < prev_blocks + cur_blocks + skip_blocks + Zs_blocks + Za_blocks) {
         int tile_id = blockIdx.x - prev_blocks - cur_blocks - skip_blocks - Zs_blocks;
-        nv_wavenet_persistent_GEMM<T_weight, T_data, 4*R, R, BATCH_UNROLL>(thread_id, params.num_samples, params.ySample, tile_id, params.batch_size, params.Wout, params.Bout, params.skipOutAccumulate + (S/R-1)*A*params.batch_size, params.out, params.outAccumulate, A, A);
+        nv_wavenet_persistent_GEMM<T_weight, T_data, 4*R, R, BATCH_UNROLL>(thread_id, params.num_samples, params.init_sample, params.num_samples_per_chunk, params.ySample, tile_id, params.batch_size, params.Wout, params.Bout, params.skipOutAccumulate + (S/R-1)*A*params.batch_size, params.out, params.outAccumulate, A, A);
     }
     else {
         int block_id = blockIdx.x - prev_blocks - cur_blocks - skip_blocks - Zs_blocks - Za_blocks;
-        nv_wavenet_persistent_softmax<T_weight, T_data, R, S, A, 1>(block_id, params.batch_size, params.num_layers, params.num_samples, params.maxDilation, params.outAccumulate, params.outputSelectors, params.p, params.yOut, params.yInPrev, params.yInCur, params.ySample, params.xt, params.a_prev, params.h, params.skip_out, params.skipOutAccumulate, params.dumpActivations);
+        nv_wavenet_persistent_softmax<T_weight, T_data, R, S, A, 1>(block_id, params.batch_size, params.num_layers, params.num_samples, params.init_sample, params.num_samples_per_chunk, params.maxDilation, params.outAccumulate, params.outputSelectors, params.p, params.yOut, params.yInPrev, params.yInCur, params.ySample, params.xt, params.a_prev, params.h, params.skip_out, params.skipOutAccumulate, params.dumpActivations);
     }
 }
 
@@ -518,13 +518,14 @@ bool launch_persistent(nv_wavenet_params<T_weight, T_data> params, cudaStream_t 
     int occ = getOccupancy(0, block.x*block.y*block.z,(void*)nv_wavenet_persistent<T_weight, T_data, R, S, A, BATCH_UNROLL>);
     printf("%d blocks, %d blocks per SM\n", grid.x, occ);
     assert(occ>0);
-    gpuErrChk(cudaMemset((void*)params.hSample,0,params.num_layers*params.batch_size*sizeof(int)));
-    gpuErrChk(cudaMemset((void*)params.ySample,0,params.batch_size*sizeof(int)));
-    initializeActivations<T_data,R><<<params.num_layers*params.batch_size,R,0,stream>>>(params.xt, params.h, params.a_prev, params.num_layers, params.batch_size);
-    initializeActivationsGeneric<T_data><<<(params.maxDilation+1)*(params.num_layers+1)*params.batch_size,R,0,stream>>>(params.xt);
-    initializeActivationsGeneric<T_data><<<params.num_layers*params.batch_size,S,0,stream>>>(params.skip_out);
-    initializeActivationsGeneric<T_data><<<(S/R)*params.batch_size,A,0,stream>>>(params.skipOutAccumulate);
-    initializeActivationsGeneric<T_data><<<(A/R)*params.batch_size,A,0,stream>>>(params.outAccumulate);
+    if(!params.init_sample) {
+      gpuErrChk(cudaMemset((void*)params.ySample,0,params.batch_size*sizeof(int)));
+      initializeActivations<T_data,R><<<params.num_layers*params.batch_size,R,0,stream>>>(params.xt, params.h, params.a_prev, params.num_layers, params.batch_size);
+      initializeActivationsGeneric<T_data><<<(params.maxDilation+1)*(params.num_layers+1)*params.batch_size,R,0,stream>>>(params.xt);
+      initializeActivationsGeneric<T_data><<<params.num_layers*params.batch_size,S,0,stream>>>(params.skip_out);
+      initializeActivationsGeneric<T_data><<<(S/R)*params.batch_size,A,0,stream>>>(params.skipOutAccumulate);
+      initializeActivationsGeneric<T_data><<<(A/R)*params.batch_size,A,0,stream>>>(params.outAccumulate);
+    }
     void* p_params = {&params};
     cudaError_t code = cudaLaunchCooperativeKernel((void*)nv_wavenet_persistent<T_weight,T_data,R,S,A,BATCH_UNROLL>, grid, block, &p_params, 0, stream);
     gpuAssert(code, __FILE__, __LINE__, false);

--- a/nv_wavenet_test.cu
+++ b/nv_wavenet_test.cu
@@ -250,7 +250,9 @@ void runTest(int num_layers, int max_dilation, int batch_size, int num_iteration
         int* mcYout = (int*)malloc(samples_per_iteration*batch_size*sizeof(int));
 
         ref.run(samples_per_iteration, batch_size, refYout);
-        assert(infer->run(samples_per_iteration, batch_size, mcYout, batch_size_per_block, true));
+
+        assert(infer->run_chunks(7, [](int*, int, int){}, samples_per_iteration, batch_size, mcYout, batch_size_per_block));
+
         gpuErrChk(cudaDeviceSynchronize());
 
         // Check results
@@ -301,6 +303,8 @@ void runTest(int num_layers, int max_dilation, int batch_size, int num_iteration
         for (int i=0; i<samples_per_iteration*batch_size; i++) {
             assert(refYout[i] == mcYout[i]);
         }
+        free(mcYout);
+        free(refYout);
 
         printf("SUCCESS!\n");
     }
@@ -362,5 +366,4 @@ int main(int argc, char* argv[]) {
     runTest<float,float,64,256, 256>(num_layers, MAX_DILATION, batch_size, 2, SAMPLES_PER_ITERATION, 2);
     printf("   Testing Persistent\n");
     runTest<float,float,64,256, 256>(num_layers, MAX_DILATION, batch_size, 2, SAMPLES_PER_ITERATION, 3);
-
 }

--- a/pytorch/integration_test.py
+++ b/pytorch/integration_test.py
@@ -1,0 +1,52 @@
+# *****************************************************************************
+#  Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# 
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#      * Neither the name of the NVIDIA CORPORATION nor the
+#        names of its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+#  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+#  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+#  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# *****************************************************************************
+"""
+Tests that the NV-WaveNet class is producing audio
+"""
+import torch
+from scipy.io.wavfile import write
+import nv_wavenet
+from wavenet import WaveNet
+import utils
+import json
+
+if __name__ == '__main__':
+    config = json.loads(open('config.json').read())
+    wavenet_config = config["wavenet_config"]
+    model = WaveNet(**wavenet_config).cuda()
+    weights = model.export_weights()
+    wavenet = nv_wavenet.NVWaveNet(**weights)
+    num_samples = 10*1000
+    batch_size = config['train_config']['batch_size']
+    cond_input = torch.zeros([2 * wavenet_config['n_residual_channels'], batch_size, wavenet_config['n_layers'], num_samples]).cuda()
+
+    samples = wavenet.infer(cond_input, nv_wavenet.Impl.PERSISTENT)[0]
+   
+    audio = utils.mu_law_decode_numpy(samples.cpu().numpy(), 256)
+    audio = utils.MAX_WAV_VALUE * audio
+    wavdata = audio.astype('int16')
+    write('audio.wav',16000, wavdata)


### PR DESCRIPTION
The change allows the kernels to reuse last activations when invoked on subsequent chunks.
The host code has a new interface, nvWavenetInfer::run_chunks(...), which accepts
a lambda callback for any CPU postprocessing, one chunk per call (encoding, sending
over the network, etc.). Performance of non-chunked codepath is unaffected, and
the per-chunk overhead is negligible for realistic chunk sizes.
However, the whole activation tensors still need to be allocated on the GPU.

Added integration test to ensure pytorch runs the C++ model to completion.