### PR TITLE
Add support for 128 residual (R) channels with S=A=256.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,11 @@
 NVCC = nvcc
 
 ARCH=sm_70
-NVCC_FLAGS = -arch=$(ARCH) -std=c++11 
+NVCC_FLAGS = -arch=$(ARCH) -std=c++11  -g
 NVCC_FLAGS += --use_fast_math
 
 MAX_REGS = 128
+#MAX_REGS = 64
 
 HEADERS = nv_wavenet_util.cuh \
 		  nv_wavenet_singleblock.cuh \
@@ -52,7 +53,7 @@ nv_wavenet_perf : nv_wavenet_perf.cu $(HEADERS)
 	$(NVCC) $(NVCC_FLAGS) -maxrregcount $(MAX_REGS) --ptxas-options=-v nv_wavenet_perf.cu -o nv_wavenet_perf
 
 nv_wavenet_test : nv_wavenet_test.cu matrix.cpp matrix.h nv_wavenet_reference.cpp $(HEADERS)
-	$(NVCC) $(NVCC_FLAGS) -lineinfo -maxrregcount $(MAX_REGS) nv_wavenet_test.cu matrix.cpp nv_wavenet_reference.cpp -o nv_wavenet_test
+	$(NVCC) $(NVCC_FLAGS) -lineinfo -maxrregcount $(MAX_REGS) --ptxas-options=-v nv_wavenet_test.cu matrix.cpp nv_wavenet_reference.cpp -o nv_wavenet_test
 
 math_test : math_test.cu matrix_math.cuh matrix.cpp softmax.cuh
 	$(NVCC) $(NVCC_FLAGS) math_test.cu matrix.cpp -lineinfo -o math_test

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Channel counts are provided as template parameters.  The following channel count
 * 32 residual channels, 128 skip channels, 256 audio channels
 * 64 residual channels, 128 skip channels, 256 audio channels
 * 64 residual channels, 256 skip channels, 256 audio channels
+* 128 residual channels, 256 skip channels, 256 audio channels
 
 The implementation provides three different variants, with different complexity, sample rate, throughput and resource characteristics:
 

--- a/nv_wavenet.cuh
+++ b/nv_wavenet.cuh
@@ -556,55 +556,55 @@ class nvWavenetInfer {
                 assert(batch_size_per_block < 5);
                 if (batch_size_per_block == 4) {
                     assert(batch_size%4==0);
-                    result = launch_persistent<T_weight, T_data, R, S, A, 4>(params, stream);
+                    result = launch_persistent<T_weight, T_data, R, S, A, 4>()(params, stream);
                 }
                 else if (batch_size_per_block == 3) {
                     assert(batch_size%3==0);
-                    result =  launch_persistent<T_weight, T_data, R, S, A, 3>(params, stream);
+                    result =  launch_persistent<T_weight, T_data, R, S, A, 3>()(params, stream);
                 }
                 else if (batch_size_per_block == 2) {
                     assert(batch_size%2==0);
-                    result =  launch_persistent<T_weight, T_data, R, S, A, 2>(params, stream);
+                    result =  launch_persistent<T_weight, T_data, R, S, A, 2>()(params, stream);
                 }
                 else {
-                    result =  launch_persistent<T_weight, T_data, R, S, A, 1>(params, stream);
+                    result =  launch_persistent<T_weight, T_data, R, S, A, 1>()(params, stream);
                 }
-            }
-            else if (impl == DUAL_BLOCK) {
+            } 
+            else if (R <= 64 && impl == DUAL_BLOCK) {
                 assert(batch_size_per_block < 5);
                 if (batch_size_per_block == 4) {
                     assert(batch_size%4==0);
-                    result =  launch_dualBlock<T_weight, T_data, R, S, A, 4>(params, stream);
+                    result =  launch_dualBlock<T_weight, T_data, R, S, A, 4>()(params, stream);
                 }
                 else if (batch_size_per_block == 3) {
                     assert(batch_size%3==0);
-                    result =  launch_dualBlock<T_weight, T_data, R, S, A, 3>(params, stream);
+                    result =  launch_dualBlock<T_weight, T_data, R, S, A, 3>()(params, stream);
                 }
                 else if (batch_size_per_block == 2) {
                     assert(batch_size%2==0);
-                    result =  launch_dualBlock<T_weight, T_data, R, S, A, 2>(params, stream);
+                    result =  launch_dualBlock<T_weight, T_data, R, S, A, 2>()(params, stream);
                 }
                 else {
-                    result =  launch_dualBlock<T_weight, T_data, R, S, A, 1>(params, stream);
+                    result =  launch_dualBlock<T_weight, T_data, R, S, A, 1>()(params, stream);
                 }
 
             }
-            else {
+            else if (R <= 64){
                 assert(batch_size_per_block < 5);
                 if (batch_size_per_block == 4) {
                     assert(batch_size%4==0);
-                    result =  launch_singleBlock<T_weight, T_data, R, S, A, 4>(params, stream);
+                    result =  launch_singleBlock<T_weight, T_data, R, S, A, 4>()(params, stream);
                 }
                 else if (batch_size_per_block == 3) {
                     assert(batch_size%3==0);
-                    result =  launch_singleBlock<T_weight, T_data, R, S, A, 3>(params, stream);
+                    result =  launch_singleBlock<T_weight, T_data, R, S, A, 3>()(params, stream);
                 }
                 else if (batch_size_per_block == 2) {
                     assert(batch_size%2==0);
-                    result =  launch_singleBlock<T_weight, T_data, R, S, A, 2>(params, stream);
+                    result =  launch_singleBlock<T_weight, T_data, R, S, A, 2>()(params, stream);
                 }
                 else {
-                    result =  launch_singleBlock<T_weight, T_data, R, S, A, 1>(params, stream);
+                    result =  launch_singleBlock<T_weight, T_data, R, S, A, 1>()(params, stream);
                 }
             }
             if (yOut != NULL) {

--- a/nv_wavenet_test.cu
+++ b/nv_wavenet_test.cu
@@ -366,4 +366,8 @@ int main(int argc, char* argv[]) {
     runTest<float,float,64,256, 256>(num_layers, MAX_DILATION, batch_size, 2, SAMPLES_PER_ITERATION, 2);
     printf("   Testing Persistent\n");
     runTest<float,float,64,256, 256>(num_layers, MAX_DILATION, batch_size, 2, SAMPLES_PER_ITERATION, 3);
+
+    printf("Testing R=128, S=256\n");
+    printf("   Testing Persistent\n");
+    runTest<float,float,128,256, 256>(num_layers, MAX_DILATION, batch_size, 2, SAMPLES_PER_ITERATION, 3);
 }


### PR DESCRIPTION
Added support for 128 residual (R) channels with S=A=256. Use constant number of blocks for softmax in persistent mode to reduce total number of blocks. Added CUDA device selection option.

A major change to note is that the "launch_" family of functions have been changed to functors in order to support partial template specialization.